### PR TITLE
Preserve custom domain on deploy (fix CNAME getting dropped)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,3 +48,7 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./_build/html
+        # Preserve the custom domain across deploys. Without this the CNAME
+        # file (which lives at the repo root, not in _build/html) is dropped
+        # on every publish and GitHub Pages resets the custom domain.
+        cname: tom-nicholas.com

--- a/blog/2026/virtual-zarr.md
+++ b/blog/2026/virtual-zarr.md
@@ -173,7 +173,7 @@ ds = xr.open_zarr(session.store, group="ABI-L2-MCMIPF/post-2023-04-19")
 ds
 ```
 
-```{code-block}
+```{code-block} text
 :caption: The entire GOES-16 MCMIPF archive opened as a single Xarray Dataset — petabytes addressable through one entrypoint, without copying any data.
 
 <xarray.Dataset> Size: 2PB


### PR DESCRIPTION
## Problem
Every deploy resets the GitHub Pages custom domain (`tom-nicholas.com`), so it has to be re-entered in the Pages settings and the re-deploy effectively breaks the domain.

## Cause
`deploy.yml` builds the site into `_build/html` and publishes **only that folder** to `gh-pages` via `peaceiris/actions-gh-pages` (`publish_dir: ./_build/html`). The `CNAME` file lives at the repo root and MyST never copies it into `_build/html`, so each deploy force-replaces `gh-pages` with output that has no CNAME — and GitHub Pages resets the custom domain.

## Fix
Set the action's built-in `cname:` option so the CNAME is written into the published output on every deploy.

Also tagged the xarray `Dataset` output code-block in the new GOES-16 post with a `text` language to silence a MyST build warning.